### PR TITLE
Fix broken smash.gg widget caused by api update

### DIFF
--- a/StreamControl/widgets/smashggwidget.cpp
+++ b/StreamControl/widgets/smashggwidget.cpp
@@ -252,8 +252,8 @@ void SmashggWidget::processTournamentJson()
                     QJsonObject player2 = e2Members[0].toObject()["player"].toObject();
                     e1Name = player1["gamerTag"].toString();
                     e2Name = player2["gamerTag"].toString();
-                    e1Country = player1["country"].toString();
-                    e2Country = player2["country"].toString();
+                    e1Country = player1["user"].toObject()["location"].toObject()["country"].toString();
+                    e2Country = player2["user"].toObject()["location"].toObject()["country"].toString();
                 }
                 matchDetails.append(e1Name);
                 matchDetails.append(e2Name);

--- a/StreamControl/widgets/smashggwidget.h
+++ b/StreamControl/widgets/smashggwidget.h
@@ -79,7 +79,7 @@ private:
 
     QString urlString = "https://api.smash.gg/gql/alpha";
     QString tourneysRequest =
-            R"(query TournamentsByOwner($ownerId: Int, $perPage: Int) {
+            R"(query TournamentsByOwner($ownerId: ID, $perPage: Int) {
                 tournaments(query: {
                     perPage: $perPage
                     filter: {
@@ -111,7 +111,11 @@ private:
                                         player {
                                             gamerTag
                                             prefix
-                                            country
+                                            user {
+                                                location {
+                                                    country
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
smash.gg has made breaking updates to their GraphQL API, causing request issues in the smash.gg widget.
This pull request updates the widget's request and response handling to accommodate these API updates.