### PR TITLE
WIP: Add imageSelect widget

### DIFF
--- a/StreamControl/mainwindow.h
+++ b/StreamControl/mainwindow.h
@@ -76,6 +76,7 @@ public slots:
     void addCheckBox(QDomElement, QWidget*);
     void addComboBox(QDomElement, QWidget*);
     void addRadioGroup(QDomElement, QWidget*);
+    void addImageSelect(QDomElement, QWidget*);
     void addTweetWidget(QDomElement, QWidget*);
     void addProviderWidget(QDomElement, QWidget*, QMap<QString, QObject*> widgetList, ProviderWidgetBuilder::Provider);
     QString addTabWidget(QDomElement, QWidget*);

--- a/StreamControl/scimageselect.cpp
+++ b/StreamControl/scimageselect.cpp
@@ -1,0 +1,71 @@
+#include <QGridLayout>
+#include <QDir>
+
+#include "scimageselect.h"
+
+ScImageSelect::ScImageSelect(QWidget *parent, QString path, QString defaultImageSubPath, int optionWidth, int optionHeight, int optionsColumns) : QPushButton(parent)
+{
+    this->path = path.endsWith('/') ? path : path + "/";
+    if (!defaultImageSubPath.isEmpty()) {
+        this->selectedImagePath = this->path + defaultImageSubPath;
+    }
+    this->optionWidth = optionWidth;
+    this->optionHeight = optionHeight;
+    this->optionsColumns = optionsColumns;
+    this->setIcon(QIcon(this->selectedImagePath));
+    optionsWidget = new QWidget(this->parentWidget());
+    connect(this, SIGNAL(clicked()), this, SLOT(displayOptions()));
+}
+
+void ScImageSelect::displayOptions() {
+    // if options are already displayed, hide them and return
+    if (!optionsWidget->findChildren<QPushButton*>().isEmpty()) {
+        qDeleteAll(optionsWidget->findChildren<QPushButton*>());
+        return;
+    }
+
+    qDeleteAll(optionsWidget->findChildren<QPushButton*>());
+    QDir dir = QDir(path);
+    QStringList filters;
+    filters << "*.png" << "*.jpg" << "*.bmp";
+    QStringList options = dir.entryList(filters, QDir::Files|QDir::NoDotAndDotDot);
+    for (int i = 0; i < options.size(); i++) {
+        QPushButton *optionButton = new QPushButton(optionsWidget);
+        optionButton->setGeometry(QRect(optionWidth * (i % 8),
+                                        optionHeight * (i/8),
+                                        optionWidth,
+                                        optionHeight));
+        optionButton->setIcon(QIcon(path + options[i]));
+        optionButton->setIconSize(optionButton->size());
+        optionButton->setObjectName(path + options[i]);
+        connect(optionButton, SIGNAL(clicked()), this, SLOT(selectOption()));
+        optionButton->show();
+    }
+    optionsWidget->adjustSize();
+    optionsWidget->move(this->geometry().center().x() - (optionsWidget->width() / 2),
+                        this->geometry().bottom());
+    optionsWidget->show();
+}
+
+void ScImageSelect::selectOption() {
+    selectedImagePath = sender()->objectName();
+    this->setIcon(QIcon(selectedImagePath));
+    qDeleteAll(optionsWidget->findChildren<QPushButton*>());
+}
+
+void ScImageSelect::setName(QString name, QString dataSetName) {
+    this->name = name;
+    this->dataSetName = dataSetName;
+}
+
+QString ScImageSelect::getName() {
+    return name;
+}
+
+QString ScImageSelect::getDataSetName() {
+    return dataSetName;
+}
+
+QString ScImageSelect::getSelectedImagePath() {
+    return selectedImagePath;
+}

--- a/StreamControl/scimageselect.h
+++ b/StreamControl/scimageselect.h
@@ -1,0 +1,37 @@
+#ifndef SCIMAGESELECT_H
+#define SCIMAGESELECT_H
+
+#include <QPushButton>
+
+class QGridLayout;
+
+class ScImageSelect : public QPushButton
+{
+    Q_OBJECT
+
+public:
+    ScImageSelect(QWidget *parent = 0, QString path = "", QString defaultImage = "", int optionWidth = 32, int optionHeight = 32, int optionsColumns = 8);
+
+private slots:
+    void displayOptions();
+    void selectOption();
+    void setName(QString, QString);
+
+public slots:
+    QString getName();
+    QString getDataSetName();
+    QString getSelectedImagePath();
+
+private:
+    QString name;
+    QString dataSetName;
+    QString path;
+    QWidget *optionsWidget;
+    int optionWidth;
+    int optionHeight;
+    int optionsColumns;
+    QString selectedImagePath;
+};
+
+
+#endif // SCIMAGESELECT_H


### PR DESCRIPTION
Example use in layout file:
`<imageSelect id="pChar1" x="10" y="330" width="64" height="64"
             optionWidth="32" optionHeight="32" optionsColumns="8"
             path="browserfiles/characters" defaultValue="Mario.png" />`
This will display the image `browserfiles/characters/Mario.png`.

If you click this widget, it will let you choose any image in the specified path by previewing all images in a clickable grid. The chosen image's path will be written to the output file, relative to the output path.